### PR TITLE
refactor(scheduler): simplify guild management logic

### DIFF
--- a/cmd/disruptor/main.go
+++ b/cmd/disruptor/main.go
@@ -123,7 +123,7 @@ func initDiscordProcesses(cfg config.Config, logger *slog.Logger, database db.Da
 	err = session.AddCommands(
 		commands.Play(lava),
 		commands.Disconnect(lava),
-		commands.Next(manager),
+		commands.Next(manager, database),
 		commands.Interval(database, manager),
 		commands.Chance(database),
 	)

--- a/internal/commands/interval.go
+++ b/internal/commands/interval.go
@@ -99,8 +99,8 @@ func (i interval) handle(d discord.SlashCommandInteractionData, event *handler.C
 		return fmt.Errorf("failed to update guild interval: %w", err)
 	}
 
-	if err := i.manager.AddGuild(guildID.String(), guild.Interval); err != nil {
-		return fmt.Errorf("failed to add guild to manager: %w", err)
+	if err := i.manager.AddScheduler(scheduler.WithInterval(guild.Interval)); err != nil {
+		return fmt.Errorf("failed to add guild to voice audio scheduler manager: %w", err)
 	}
 
 	embed := discord.NewEmbedBuilder()

--- a/internal/handlers/guild_join.go
+++ b/internal/handlers/guild_join.go
@@ -29,7 +29,7 @@ func GuildJoin(l *slog.Logger, d db.Database, m scheduler.Manager) func(*events.
 			return
 		}
 
-		if err := m.AddGuild(guild.ID.String(), guild.Interval); err != nil {
+		if err := m.AddScheduler(scheduler.WithInterval(guild.Interval)); err != nil {
 			l.Error("Failed to add guild to voice audio scheduler manager", slog.Any("error", err))
 		}
 	}

--- a/internal/handlers/guild_leave.go
+++ b/internal/handlers/guild_leave.go
@@ -26,9 +26,5 @@ func GuildLeave(l *slog.Logger, d db.Database, m scheduler.Manager) func(*events
 			l.Error("Failed to find guild in store", slog.Any("error", err))
 			return
 		}
-
-		if err := m.RemoveGuild(gr.Guild.ID.String()); err != nil {
-			l.Error("Failed to remove guild from voice audio scheduler manager", slog.Any("error", err))
-		}
 	}
 }

--- a/internal/handlers/guild_ready.go
+++ b/internal/handlers/guild_ready.go
@@ -45,8 +45,7 @@ func (t guildReadyTask) Execute(ctx context.Context) error {
 		}
 	}
 
-	// Add guild to voice audio scheduler manager
-	if err := t.manager.AddGuild(guild.ID.String(), guild.Interval); err != nil {
+	if err := t.manager.AddScheduler(scheduler.WithInterval(guild.Interval)); err != nil {
 		return fmt.Errorf("failed to add guild %s to voice audio scheduler manager: %w", t.guildID, err)
 	}
 

--- a/internal/scheduler/manager.go
+++ b/internal/scheduler/manager.go
@@ -13,16 +13,13 @@ import (
 type Manager interface {
 	Start() error
 	Stop() error
-	GetSchedulerForGuild(guildID string) (Scheduler, error)
+
 	AddScheduler(opts ...Option[scheduler]) error
-	AddGuild(guildID string, interval time.Duration) error
-	RemoveGuild(guildID string) error
+	GetScheduler(interval time.Duration) (Scheduler, bool)
 }
 
 type manager struct {
-	intervalGroups map[string]Scheduler
-
-	maxGuildsPerScheduler int
+	schedulers map[time.Duration]Scheduler
 
 	// Dependencies
 	session  *disruptor.Session
@@ -31,10 +28,4 @@ type manager struct {
 	logger   *slog.Logger
 
 	mu sync.RWMutex
-}
-
-func WithMaxGuildsPerScheduler(maxGuilds int) Option[manager] {
-	return func(m *manager) {
-		m.maxGuildsPerScheduler = maxGuilds
-	}
 }

--- a/internal/scheduler/manager_impl.go
+++ b/internal/scheduler/manager_impl.go
@@ -3,12 +3,9 @@ package scheduler
 import (
 	"fmt"
 	"log/slog"
-	"slices"
 	"time"
 
 	"golang.org/x/sync/errgroup"
-
-	"github.com/disgoorg/snowflake/v2"
 
 	"github.com/XanderD99/disruptor/internal/disruptor"
 	"github.com/XanderD99/disruptor/internal/lavalink"
@@ -17,12 +14,11 @@ import (
 
 func NewManager(logger *slog.Logger, session *disruptor.Session, db db.Database, lavalink lavalink.Lavalink, opts ...Option[manager]) Manager {
 	m := &manager{
-		intervalGroups:        make(map[string]Scheduler),
-		maxGuildsPerScheduler: 100,
-		session:               session,
-		lavalink:              lavalink,
-		db:                    db,
-		logger:                logger.With(slog.String("component", "voice_audio_scheduler_manager")),
+		schedulers: make(map[time.Duration]Scheduler),
+		session:    session,
+		lavalink:   lavalink,
+		db:         db,
+		logger:     logger.With(slog.String("component", "voice_audio_scheduler_manager")),
 	}
 
 	for _, opt := range opts {
@@ -36,10 +32,10 @@ func (m *manager) Start() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.logger.Info("starting voice audio scheduler manager", slog.Int("groups", len(m.intervalGroups)))
+	m.logger.Info("starting voice audio scheduler manager", slog.Int("groups", len(m.schedulers)))
 
-	for key, group := range m.intervalGroups {
-		m.logger.Debug("starting interval group", slog.Group("scheduler", slog.String("key", key), slog.Duration("interval", group.GetInterval())))
+	for interval, group := range m.schedulers {
+		m.logger.Debug("starting interval group", slog.Group("scheduler", slog.Duration("interval", interval)))
 		go group.Start()
 	}
 
@@ -53,17 +49,17 @@ func (m *manager) Stop() error {
 	m.logger.Info("stopping voice audio scheduler manager")
 
 	var eg errgroup.Group
-	for key, group := range m.intervalGroups {
+	for interval, group := range m.schedulers {
 		eg.Go(func() error {
 			if err := group.Stop(); err != nil {
-				m.logger.Error("failed to stop interval group", slog.Group("scheduler", slog.String("key", key)), slog.Any("error", err))
-				return fmt.Errorf("failed to stop interval group %s: %w", key, err)
+				m.logger.Error("failed to stop interval group", slog.Group("scheduler", slog.Duration("interval", interval)), slog.Any("error", err))
+				return fmt.Errorf("failed to stop interval group %v: %w", interval, err)
 			}
 			return nil
 		})
 	}
 
-	m.intervalGroups = make(map[string]Scheduler)
+	m.schedulers = make(map[time.Duration]Scheduler)
 
 	if err := eg.Wait(); err != nil {
 		m.logger.Error("error stopping some interval groups", slog.Any("error", err))
@@ -74,6 +70,15 @@ func (m *manager) Stop() error {
 	return nil
 }
 
+func (m *manager) GetScheduler(interval time.Duration) (Scheduler, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if scheduler, exists := m.schedulers[interval]; exists {
+		return scheduler, true
+	}
+	return nil, false
+}
+
 func (m *manager) AddScheduler(opts ...Option[scheduler]) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -82,174 +87,16 @@ func (m *manager) AddScheduler(opts ...Option[scheduler]) error {
 	group := NewScheduler(m.logger, handler, opts...)
 	interval := group.GetInterval()
 
-	// Check if we can update an existing scheduler with capacity
-	if key, group := m.findSchedulerWithCapacity(interval); group != nil {
-		logger := m.logger.With(slog.Group("scheduler", slog.Duration("interval", interval)), slog.String("key", key))
-
-		logger.Debug("updating existing scheduler with capacity")
-
-		if err := group.UpdateOptions(opts...); err != nil {
-			m.logger.Error("failed to update interval group options", slog.Any("error", err))
-			return fmt.Errorf("failed to update interval group %s: %w", interval, err)
-		}
-
+	// Check if scheduler for this interval already exists
+	if _, exists := m.schedulers[interval]; exists {
+		m.logger.Debug("updating existing scheduler", slog.Duration("interval", interval))
 		return nil
 	}
 
-	// Generate scheduler key for this interval
-	key := m.generateSchedulerKey()
-	m.intervalGroups[key] = group
+	// Create new scheduler for this interval
+	m.schedulers[interval] = group
 	go group.Start()
 
-	m.logger.Info("new interval group added", slog.Group("scheduler", slog.Duration("interval", interval)), slog.String("key", key))
+	m.logger.Info("new interval group added", slog.Duration("interval", interval))
 	return nil
-}
-
-func (m *manager) AddGuild(guildID string, interval time.Duration) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Check if guild already exists and remove from old scheduler
-	if key, group := m.findGuildInSchedulers(guildID); group != nil {
-		if group.GetInterval() == interval {
-			return nil // Guild already in correct interval
-		}
-
-		// Remove from existing group
-		if err := group.RemoveGuild(guildID); err != nil {
-			m.logger.Error("failed to remove guild from existing interval group",
-				slog.String("guild.id", guildID),
-				slog.Any("error", err))
-			return fmt.Errorf("failed to remove guild from interval group: %w", err)
-		}
-
-		// Clean up empty group
-		if len(group.GetGuilds()) == 0 {
-			if err := group.Stop(); err != nil {
-				m.logger.Error("failed to stop empty interval group", slog.Any("error", err))
-			}
-			delete(m.intervalGroups, key)
-		}
-	}
-
-	// Find or create a scheduler with capacity for this interval
-	schedulerKey, scheduler := m.findOrCreateSchedulerWithCapacity(interval)
-
-	if err := scheduler.AddGuild(guildID); err != nil {
-		m.logger.Error("failed to add guild to interval group",
-			slog.String("guild.id", guildID),
-			slog.Any("error", err))
-		return err
-	}
-
-	m.logger.Info("guild added to scheduler",
-		slog.String("guild.id", guildID),
-		slog.Duration("interval", interval),
-		slog.String("scheduler_key", schedulerKey))
-
-	return nil
-}
-
-func (m *manager) RemoveGuild(guildID string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Find the scheduler containing this guild
-	key, scheduler := m.findGuildInSchedulers(guildID)
-	if scheduler == nil {
-		return fmt.Errorf("guild %s not found in scheduler", guildID)
-	}
-
-	if err := scheduler.RemoveGuild(guildID); err != nil {
-		m.logger.Error("failed to remove guild from interval group",
-			slog.String("guild.id", guildID),
-			slog.Any("error", err))
-		return err
-	}
-
-	// Clean up empty groups
-	if len(scheduler.GetGuilds()) == 0 {
-		if err := scheduler.Stop(); err != nil {
-			m.logger.Error("failed to stop empty interval group", slog.Any("error", err))
-		}
-		delete(m.intervalGroups, key)
-	}
-
-	m.logger.Info("guild removed from scheduler", slog.String("guild.id", guildID))
-
-	return nil
-}
-
-// Public method with locking
-func (m *manager) GetSchedulerForGuild(guildID string) (Scheduler, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	_, scheduler := m.findGuildInSchedulers(guildID)
-	if scheduler == nil {
-		return nil, fmt.Errorf("guild %s not found in scheduler", guildID)
-	}
-	return scheduler, nil
-}
-
-// findOrCreateSchedulerWithCapacity finds an existing scheduler with capacity or creates a new one
-func (m *manager) findOrCreateSchedulerWithCapacity(interval time.Duration) (string, Scheduler) {
-	// First, try to find an existing scheduler with capacity for this interval
-	if key, scheduler := m.findSchedulerWithCapacity(interval); scheduler != nil {
-		return key, scheduler
-	}
-
-	handler := NewHandler(m.session, m.db, m.lavalink)
-	scheduler := NewScheduler(
-		m.logger,
-		handler,
-		WithInterval(interval),
-	)
-
-	// If no existing scheduler has capacity, create a new one
-	key := m.generateSchedulerKey()
-	m.intervalGroups[key] = scheduler
-	go scheduler.Start()
-
-	m.logger.Info("new scheduler created", slog.Group("scheduler",
-		slog.String("key", key),
-		slog.Duration("interval", interval),
-	))
-
-	return key, scheduler
-}
-
-// findSchedulerWithCapacity finds a scheduler with available capacity for the given interval
-func (m *manager) findSchedulerWithCapacity(interval time.Duration) (string, Scheduler) {
-	for key, scheduler := range m.intervalGroups {
-		if scheduler.GetInterval() == interval && m.hasCapacity(scheduler) {
-			return key, scheduler
-		}
-	}
-	return "", nil
-}
-
-// hasCapacity checks if a scheduler has capacity for more guilds
-func (m *manager) hasCapacity(scheduler Scheduler) bool {
-	if m.maxGuildsPerScheduler <= 0 {
-		return true // No limit set
-	}
-
-	return len(scheduler.GetGuilds()) < m.maxGuildsPerScheduler
-}
-
-// findGuildInSchedulers finds which scheduler contains the given guild
-func (m *manager) findGuildInSchedulers(guildID string) (string, Scheduler) {
-	for key, scheduler := range m.intervalGroups {
-		guilds := scheduler.GetGuilds()
-		if slices.Contains(guilds, guildID) {
-			return key, scheduler
-		}
-	}
-	return "", nil
-}
-
-// generateSchedulerKey creates a unique key for schedulers
-func (m *manager) generateSchedulerKey() string {
-	return snowflake.New(time.Now()).String()
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -5,9 +5,6 @@ import (
 )
 
 type Scheduler interface {
-	AddGuild(guildID string) error
-	RemoveGuild(guildID string) error
-	GetGuilds() []string
 	GetInterval() time.Duration
 	GetNextIntervalTime() time.Time
 	Start()


### PR DESCRIPTION
Replaces guild-specific management in schedulers with interval-based logic, reducing complexity and improving scalability.

Removes methods related to guild addition/removal, consolidating scheduler creation and retrieval by interval.

Updates command and handler implementations to reflect the new scheduler structure.